### PR TITLE
[chore/sc-110051]: Add category param in article documentation

### DIFF
--- a/docs/api/4-checkout-creation/4-checkout-creation.mdx
+++ b/docs/api/4-checkout-creation/4-checkout-creation.mdx
@@ -267,7 +267,8 @@ event_date | [ISO 8601](https://es.wikipedia.org/wiki/ISO_8601) | No | Permite d
   "discount_rate": 200,
   "description": "Movimiento de cuarzo de alta precisión",
   "url": "http://www.chanel.com/fragrance-beauty/Fragrance-N05-88145/sku/138083",
-  "image_url": "http://www.chanel.com/fragrance-beauty/Fragrance-N05-88145/sku/138083/product_01.jpg"
+  "image_url": "http://www.chanel.com/fragrance-beauty/Fragrance-N05-88145/sku/138083/product_01.jpg",
+  "category": "Joyería"
 }
 ```
 
@@ -283,6 +284,7 @@ price | [decimal](../api-reference#decimals) | <t id="table.yes">Sí</t> | Preci
 tax_rate | [decimal](../api-reference#decimals) | No | Tasa de impuestos en el precio.
 discount | [decimal](../api-reference#decimals) | No | Importe de descuento en el precio.
 discount_rate | [decimal](../api-reference#decimals) | No | Tasa de descuento en el precio.
+category | string | No | Categoría del artículo.
 
 
 ## customer

--- a/i18n/en/docusaurus-plugin-content-docs/current/api/4-checkout-creation/4-checkout-creation.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/api/4-checkout-creation/4-checkout-creation.mdx
@@ -267,7 +267,8 @@ event_date | [ISO 8601](https://es.wikipedia.org/wiki/ISO_8601) | No | It allows
   "discount_rate": 200,
   "description": "High-precision quartz movement",
   "url": "http://www.chanel.com/fragrance-beauty/Fragrance-N05-88145/sku/138083",
-  "image_url": "http://www.chanel.com/fragrance-beauty/Fragrance-N05-88145/sku/138083/product_01.jpg"
+  "image_url": "http://www.chanel.com/fragrance-beauty/Fragrance-N05-88145/sku/138083/product_01.jpg",
+  "category": "Jewelry"
 }
 ```
 
@@ -283,6 +284,7 @@ price | [decimal](../api-reference#decimals) | <t id="table.yes">Sí</t> | Price
 tax_rate | [decimal](../api-reference#decimals) | No | Tax rate.
 discount | [decimal](../api-reference#decimals) | No | Discount amount.
 discount_rate | [decimal](../api-reference#decimals) | No | Discount rate.
+category | string | No | Category of the article.
 
 
 ## customer


### PR DESCRIPTION
Actualiza la documentación de creación de checkout para incluir el campo `category` de tipo `string` en `article`